### PR TITLE
IRecaptchaConfigurationService.Enabled and fixed testing.logging reference

### DIFF
--- a/src/PaulMiami.AspNetCore.Mvc.Recaptcha/IRecaptchaConfigurationService.cs
+++ b/src/PaulMiami.AspNetCore.Mvc.Recaptcha/IRecaptchaConfigurationService.cs
@@ -5,16 +5,18 @@
 
 namespace PaulMiami.AspNetCore.Mvc.Recaptcha
 {
-    public interface IRecaptchaConfigurationService
-    {
-        string JavaScriptUrl { get; }
+	public interface IRecaptchaConfigurationService
+	{
+		bool Enabled { get; }
 
-        string ValidationMessage { get; }
+		string JavaScriptUrl { get; }
 
-        string SiteKey { get; }
+		string ValidationMessage { get; }
 
-        RecaptchaControlSettings ControlSettings { get; }
+		string SiteKey { get; }
 
-        string LanguageCode { get;  }
-    }
+		RecaptchaControlSettings ControlSettings { get; }
+
+		string LanguageCode { get; }
+	}
 }

--- a/src/PaulMiami.AspNetCore.Mvc.Recaptcha/RecaptchaOptions.cs
+++ b/src/PaulMiami.AspNetCore.Mvc.Recaptcha/RecaptchaOptions.cs
@@ -17,7 +17,9 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha
 
         public string SiteKey { get; set; }
 
-        public string SecretKey { get; set; }
+		public bool Enabled { get; set; }
+
+		public string SecretKey { get; set; }
 
         public HttpMessageHandler BackchannelHttpHandler { get; set; }
 

--- a/src/PaulMiami.AspNetCore.Mvc.Recaptcha/RecaptchaService.cs
+++ b/src/PaulMiami.AspNetCore.Mvc.Recaptcha/RecaptchaService.cs
@@ -40,7 +40,15 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha
             _backChannel.Timeout = _options.BackchannelTimeout;
         }
 
-        public string SiteKey
+		public bool Enabled
+		{
+			get
+			{
+				return this._options.Enabled;
+			}
+		}
+
+		public string SiteKey
         {
             get
             {

--- a/src/PaulMiami.AspNetCore.Mvc.Recaptcha/TagHelpers/RecaptchaScriptTagHelper.cs
+++ b/src/PaulMiami.AspNetCore.Mvc.Recaptcha/TagHelpers/RecaptchaScriptTagHelper.cs
@@ -38,7 +38,13 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            var requestCulture = _contextAccessor.HttpContext.Features.Get<IRequestCultureFeature>();
+			if (!_service.Enabled)
+			{
+				output.TagName = null;
+				return;
+			}
+
+			var requestCulture = _contextAccessor.HttpContext.Features.Get<IRequestCultureFeature>();
             var language = requestCulture?.RequestCulture?.UICulture?.Name ?? _service.LanguageCode;
 
             var javaScriptUrl = _service.JavaScriptUrl;

--- a/src/PaulMiami.AspNetCore.Mvc.Recaptcha/TagHelpers/RecaptchaTagHelper.cs
+++ b/src/PaulMiami.AspNetCore.Mvc.Recaptcha/TagHelpers/RecaptchaTagHelper.cs
@@ -1,4 +1,4 @@
-﻿#region License
+﻿	#region License
 //Copyright(c) Paul Biccherai
 //Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #endregion
@@ -40,7 +40,13 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            output.TagName = "div";
+			if (!_service.Enabled)
+			{
+				output.TagName = null;
+				return;
+			}
+
+			output.TagName = "div";
             output.TagMode = TagMode.StartTagAndEndTag;
             output.Attributes.Add("class", "g-recaptcha");
             output.Attributes.Add("data-sitekey", _service.SiteKey);

--- a/src/PaulMiami.AspNetCore.Mvc.Recaptcha/ValidateRecaptchaFilter.cs
+++ b/src/PaulMiami.AspNetCore.Mvc.Recaptcha/ValidateRecaptchaFilter.cs
@@ -15,14 +15,17 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha
     {
         private IRecaptchaValidationService _service;
         private ILogger<ValidateRecaptchaFilter> _logger;
+		private readonly IRecaptchaConfigurationService _configurationService;
 
-        public ValidateRecaptchaFilter(IRecaptchaValidationService service, ILoggerFactory loggerFactory)
+		public ValidateRecaptchaFilter(IRecaptchaValidationService service, IRecaptchaConfigurationService configurationService, ILoggerFactory loggerFactory)
         {
             service.CheckArgumentNull(nameof(service));
-            loggerFactory.CheckArgumentNull(nameof(loggerFactory));
+			service.CheckArgumentNull(nameof(configurationService));
+			loggerFactory.CheckArgumentNull(nameof(loggerFactory));
 
             _service = service;
-            _logger = loggerFactory.CreateLogger<ValidateRecaptchaFilter>();
+			_configurationService = configurationService;
+			_logger = loggerFactory.CreateLogger<ValidateRecaptchaFilter>();
         }
 
         /// <inheritdoc />
@@ -75,7 +78,7 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha
 
         protected  bool ShouldValidate(AuthorizationFilterContext context)
         {
-            return string.Equals("POST", context.HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase);
+			return this._configurationService.Enabled && string.Equals("POST", context.HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/IntegrationTestFixture.cs
+++ b/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/IntegrationTestFixture.cs
@@ -51,7 +51,8 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test
             {
                 config.SecretKey = "SecretKey";
                 config.SiteKey = "SiteKey";
-                config.BackchannelHttpHandler= new TestHttpMessageHandler
+                config.Enabled = true;
+				config.BackchannelHttpHandler= new TestHttpMessageHandler
                 {
                     Sender = async req =>
                     {

--- a/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/RecaptchaServiceTest.cs
+++ b/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/RecaptchaServiceTest.cs
@@ -24,7 +24,8 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test
             return new OptionsWrapper<RecaptchaOptions>(new RecaptchaOptions
             {
                 SiteKey = _siteKey,
-                SecretKey = _secretKey
+                SecretKey = _secretKey,
+				Enabled = true
             });
         }
 
@@ -95,7 +96,17 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test
             Assert.Equal(options.Value.SiteKey, service.SiteKey);
         }
 
-        [Fact]
+		[Fact]
+		public void GetEnabledSuccess()
+		{
+			var options = GetOptions();
+
+			var service = new RecaptchaService(options);
+
+			Assert.Equal(options.Value.Enabled, service.Enabled);
+		}
+
+		[Fact]
         public void EnForceDefaultControlSettings()
         {
             var options = GetOptions();

--- a/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/TagHelpers/RecaptchaScriptTagHelperTest.cs
+++ b/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/TagHelpers/RecaptchaScriptTagHelperTest.cs
@@ -27,7 +27,8 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test.TagHelpers
             return new OptionsWrapper<RecaptchaOptions>(new RecaptchaOptions
             {
                 SiteKey = _siteKey,
-                SecretKey = _secretKey
+                SecretKey = _secretKey,
+				Enabled = true
             });
         }
 
@@ -70,7 +71,27 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test.TagHelpers
             var ex = Assert.Throws<ArgumentNullException>(() => new RecaptchaScriptTagHelper(service, null));
         }
 
-        [Fact]
+		[Fact]
+		public void DoNotRenderIfDisabled()
+		{
+			var options = GetOptions();
+			options.Value.Enabled = false;
+			var service = new RecaptchaService(options);
+			var httpContext = new DefaultHttpContext();
+			var httpContextAccessor = new Mock<IHttpContextAccessor>(MockBehavior.Strict);
+			httpContextAccessor
+				.Setup(a => a.HttpContext)
+				.Returns(httpContext)
+				.Verifiable();
+
+			var output = ProcessTagHelper(service, httpContextAccessor.Object, new TagHelperAttributeList());
+
+			Assert.Null(output.TagName);
+			Assert.False(output.IsContentModified);
+			Assert.Empty(output.Attributes);
+		}
+
+		[Fact]
         public void NoOptions()
         {
             var options = GetOptions();

--- a/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/TagHelpers/RecaptchaTagHelperTest.cs
+++ b/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/TagHelpers/RecaptchaTagHelperTest.cs
@@ -23,8 +23,9 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test.TagHelpers
             return new OptionsWrapper<RecaptchaOptions>(new RecaptchaOptions
             {
                 SiteKey = _siteKey,
-                SecretKey = _secretKey
-            });
+                SecretKey = _secretKey,
+				Enabled = true
+			});
         }
 
         private TagHelperOutput ProcessTagHelper(RecaptchaService service, TagHelperAttributeList attributes, Action<RecaptchaTagHelper> config = null)
@@ -57,7 +58,23 @@ namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test.TagHelpers
             var ex = Assert.Throws<ArgumentNullException>(() => new RecaptchaTagHelper(null));
         }
 
-        [Fact]
+
+		[Fact]
+		public void DoNotRenderIfDisabled()
+		{
+			var options = GetOptions();
+			options.Value.Enabled = false;
+			var service = new RecaptchaService(options);
+
+			var output = ProcessTagHelper(service, new TagHelperAttributeList());
+
+			Assert.Null(output.TagName);
+			Assert.False(output.IsContentModified);
+			Assert.Empty(output.Attributes);
+		}
+
+
+		[Fact]
         public void NoOptions()
         {
             var service = new RecaptchaService(GetOptions());

--- a/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/ValidateRecaptchaFilterTest.cs
+++ b/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/ValidateRecaptchaFilterTest.cs
@@ -20,297 +20,376 @@ using System.Linq;
 
 namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test
 {
-    public class ValidateRecaptchaFilterTest
-    {
-
-        [Theory]
-        [InlineData("POST")]
-        [InlineData("post")]
-        public async Task TestPostSucess(string httpMethod)
-        {
-            var recaptchaResponse = Guid.NewGuid().ToString();
-            var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
-
-            var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
-            recaptchaService
-                .Setup(a => a.ValidateResponseAsync(recaptchaResponse, ipAddress.ToString()))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
-            var filter = new ValidateRecaptchaFilter(recaptchaService.Object, NullLoggerFactory.Instance);
-
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Method = httpMethod;
-            httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
-            httpContext.Request.ContentType = "application/x-www-form-urlencoded";
-            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
-            {
-                { "g-recaptcha-response", recaptchaResponse }
-            });
-
-            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
-
-            var context = new AuthorizationFilterContext(actionContext, new[] { filter });
-
-            await filter.OnAuthorizationAsync(context);
-
-            recaptchaService.Verify();
-
-            Assert.Null(context.Result);
-            Assert.True(context.ModelState.IsValid);
-            Assert.Empty(context.ModelState);
-        }
-
-        [Theory]
-        [InlineData("POST")]
-        [InlineData("post")]
-        public async Task TestPostSucessNoIp(string httpMethod)
-        {
-            var recaptchaResponse = Guid.NewGuid().ToString();
-
-            var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
-            recaptchaService
-                .Setup(a => a.ValidateResponseAsync(recaptchaResponse, null))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
-            var filter = new ValidateRecaptchaFilter(recaptchaService.Object, NullLoggerFactory.Instance);
-
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Method = httpMethod;
-            httpContext.Request.HttpContext.Connection.RemoteIpAddress = null;
-            httpContext.Request.ContentType = "application/x-www-form-urlencoded";
-            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
-            {
-                { "g-recaptcha-response", recaptchaResponse }
-            });
-
-            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
-
-            var context = new AuthorizationFilterContext(actionContext, new[] { filter });
-
-            await filter.OnAuthorizationAsync(context);
-
-            recaptchaService.Verify();
-
-            Assert.Null(context.Result);
-            Assert.True(context.ModelState.IsValid);
-            Assert.Empty(context.ModelState);
-        }
-
-        [Theory]
-        [InlineData("POST")]
-        [InlineData("post")]
-        public async Task TestPostFail(string httpMethod)
-        {
-            var recaptchaResponse = Guid.NewGuid().ToString();
-            var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
-            var errorMessage = Guid.NewGuid().ToString();
-
-            var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
-            recaptchaService
-                .Setup(a => a.ValidateResponseAsync(recaptchaResponse, ipAddress.ToString()))
-                .Throws(new RecaptchaValidationException(errorMessage, false))
-                .Verifiable();
-
-            var sink = new TestSink();
-            var loggerFactory = new TestLoggerFactory(sink, enabled: true);
-
-            var filter = new ValidateRecaptchaFilter(recaptchaService.Object, loggerFactory);
-
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Method = httpMethod;
-            httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
-            httpContext.Request.ContentType = "application/x-www-form-urlencoded";
-            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
-            {
-                { "g-recaptcha-response", recaptchaResponse }
-            });
-
-            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
-
-            var context = new AuthorizationFilterContext(actionContext, new[] { filter });
-
-            await filter.OnAuthorizationAsync(context);
-
-            recaptchaService.Verify();
-
-            Assert.Empty(sink.Scopes);
-            Assert.Single(sink.Writes);
-            Assert.Equal($"Recaptcha validation failed. {errorMessage}", sink.Writes[0].State?.ToString());
-            var httpBadRequest = Assert.IsType<BadRequestResult>(context.Result);
-            Assert.Equal(StatusCodes.Status400BadRequest, httpBadRequest.StatusCode);
-            Assert.True(context.ModelState.IsValid);
-            Assert.Empty(context.ModelState);
-        }
-
-        [Theory]
-        [InlineData("POST")]
-        [InlineData("post")]
-        public async Task TestPostFailInvalidResponse(string httpMethod)
-        {
-            var recaptchaResponse = Guid.NewGuid().ToString();
-            var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
-            var errorMessage = Guid.NewGuid().ToString();
-            var validationMessage = Guid.NewGuid().ToString();
-
-            var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
-            recaptchaService
-                .Setup(a => a.ValidateResponseAsync(recaptchaResponse, ipAddress.ToString()))
-                .Throws(new RecaptchaValidationException(errorMessage, true))
-                .Verifiable();
-
-            recaptchaService
-                .Setup(a => a.ValidationMessage)
-                .Returns(validationMessage)
-                .Verifiable();
-
-            var sink = new TestSink();
-            var loggerFactory = new TestLoggerFactory(sink, enabled: true);
-
-            var filter = new ValidateRecaptchaFilter(recaptchaService.Object, loggerFactory);
-
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Method = httpMethod;
-            httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
-            httpContext.Request.ContentType = "application/x-www-form-urlencoded";
-            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
-            {
-                { "g-recaptcha-response", recaptchaResponse }
-            });
-
-            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
-
-            var context = new AuthorizationFilterContext(actionContext, new[] { filter });
-
-            await filter.OnAuthorizationAsync(context);
-
-            recaptchaService.Verify();
-
-            Assert.Empty(sink.Scopes);
-            Assert.Single(sink.Writes);
-            Assert.Equal($"Recaptcha validation failed. {errorMessage}", sink.Writes[0].State?.ToString());
-            Assert.Null(context.Result);
-            Assert.False(context.ModelState.IsValid);
-            Assert.NotEmpty(context.ModelState);
-            Assert.NotNull(context.ModelState["g-recaptcha-response"]);
-            Assert.Equal(1, context.ModelState["g-recaptcha-response"].Errors.Count);
-            Assert.Equal(validationMessage, context.ModelState["g-recaptcha-response"].Errors.First().ErrorMessage);
-        }
-
-        [Theory]
-        [InlineData("POST")]
-        [InlineData("post")]
-        public async Task TestPostWrongContentType(string httpMethod)
-        {
-            var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
-            recaptchaService
-                .Setup(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Verifiable();
-
-            var sink = new TestSink();
-            var loggerFactory = new TestLoggerFactory(sink, enabled: true);
-
-            var filter = new ValidateRecaptchaFilter(recaptchaService.Object, loggerFactory);
-
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Method = httpMethod;
-            httpContext.Request.ContentType = "Wrong content type";
-
-            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
-
-            var context = new AuthorizationFilterContext(actionContext, new[] { filter });
-
-            recaptchaService.Verify(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-
-            await filter.OnAuthorizationAsync(context);
-
-            Assert.Empty(sink.Scopes);
-            Assert.Single(sink.Writes);
-            Assert.Equal($"Recaptcha validation failed. The content type is 'Wrong content type', it should be form content.", sink.Writes[0].State?.ToString());
-            var httpBadRequest = Assert.IsType<BadRequestResult>(context.Result);
-            Assert.Equal(StatusCodes.Status400BadRequest, httpBadRequest.StatusCode);
-            Assert.True(context.ModelState.IsValid);
-            Assert.Empty(context.ModelState);
-        }
-
-        [Theory]
-        [InlineData("POST")]
-        [InlineData("post")]
-        public async Task TestPostFailMissingResponse(string httpMethod)
-        {
-            var recaptchaResponse = string.Empty;
-            var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
-            var errorMessage = Guid.NewGuid().ToString();
-            var validationMessage = Guid.NewGuid().ToString();
-
-            var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
-            recaptchaService
-                .Setup(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
-            recaptchaService
-                .Setup(a => a.ValidationMessage)
-                .Returns(validationMessage)
-                .Verifiable();
-
-            var filter = new ValidateRecaptchaFilter(recaptchaService.Object, NullLoggerFactory.Instance);
-
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Method = httpMethod;
-            httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
-            httpContext.Request.ContentType = "application/x-www-form-urlencoded";
-            httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
-            {
-                { "g-recaptcha-response", recaptchaResponse }
-            });
-
-            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
-
-            var context = new AuthorizationFilterContext(actionContext, new[] { filter });
-
-            await filter.OnAuthorizationAsync(context);
-
-            recaptchaService.Verify(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-
-            Assert.Null(context.Result);
-            Assert.False(context.ModelState.IsValid);
-            Assert.NotEmpty(context.ModelState);
-            Assert.NotNull(context.ModelState["g-recaptcha-response"]);
-            Assert.Equal(1, context.ModelState["g-recaptcha-response"].Errors.Count);
-            Assert.Equal(validationMessage, context.ModelState["g-recaptcha-response"].Errors.First().ErrorMessage);
-        }
-
-        [Theory]
-        [InlineData("GET")]
-        [InlineData("PUT")]
-        [InlineData("DELETE")]
-        [InlineData("HEAD")]
-        [InlineData("TRACE")]
-        [InlineData("OPTIONS")]
-        public async Task TestPostSkipping(string httpMethod)
-        {
-            var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
-            recaptchaService
-                .Setup(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
-            var filter = new ValidateRecaptchaFilter(recaptchaService.Object, NullLoggerFactory.Instance);
-
-            var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
-            actionContext.HttpContext.Request.Method = httpMethod;
-
-            var context = new AuthorizationFilterContext(actionContext, new[] { filter });
-
-            await filter.OnAuthorizationAsync(context);
-
-            recaptchaService.Verify(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
-
-            Assert.Null(context.Result);
-            Assert.True(context.ModelState.IsValid);
-            Assert.Empty(context.ModelState);
-        }
-    }
+	public class ValidateRecaptchaFilterTest
+	{
+
+		[Theory]
+		[InlineData("POST")]
+		[InlineData("post")]
+		public async Task TestPostSucess(string httpMethod)
+		{
+			var recaptchaResponse = Guid.NewGuid().ToString();
+			var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
+
+			var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
+			recaptchaService
+				.Setup(a => a.ValidateResponseAsync(recaptchaResponse, ipAddress.ToString()))
+				.Returns(Task.FromResult(0))
+				.Verifiable();
+
+			var configurationService = new Mock<IRecaptchaConfigurationService>(MockBehavior.Strict);
+			configurationService
+				.Setup(a => a.Enabled)
+				.Returns(true)
+				.Verifiable();
+
+			var filter = new ValidateRecaptchaFilter(recaptchaService.Object, configurationService.Object, NullLoggerFactory.Instance);
+
+			var httpContext = new DefaultHttpContext();
+			httpContext.Request.Method = httpMethod;
+			httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
+			httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+			httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+			{
+				{ "g-recaptcha-response", recaptchaResponse }
+			});
+
+			var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+			var context = new AuthorizationFilterContext(actionContext, new[] { filter });
+
+			await filter.OnAuthorizationAsync(context);
+
+			recaptchaService.Verify();
+
+			Assert.Null(context.Result);
+			Assert.True(context.ModelState.IsValid);
+			Assert.Empty(context.ModelState);
+		}
+
+		[Theory]
+		[InlineData("POST")]
+		[InlineData("post")]
+		public async Task TestPostSucessNoIp(string httpMethod)
+		{
+			var recaptchaResponse = Guid.NewGuid().ToString();
+
+			var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
+			recaptchaService
+				.Setup(a => a.ValidateResponseAsync(recaptchaResponse, null))
+				.Returns(Task.FromResult(0))
+				.Verifiable();
+
+			var configurationService = new Mock<IRecaptchaConfigurationService>(MockBehavior.Strict);
+			configurationService
+				.Setup(a => a.Enabled)
+				.Returns(true)
+				.Verifiable();
+
+			var filter = new ValidateRecaptchaFilter(recaptchaService.Object, configurationService.Object, NullLoggerFactory.Instance);
+
+			var httpContext = new DefaultHttpContext();
+			httpContext.Request.Method = httpMethod;
+			httpContext.Request.HttpContext.Connection.RemoteIpAddress = null;
+			httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+			httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+			{
+				{ "g-recaptcha-response", recaptchaResponse }
+			});
+
+			var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+			var context = new AuthorizationFilterContext(actionContext, new[] { filter });
+
+			await filter.OnAuthorizationAsync(context);
+
+			recaptchaService.Verify();
+
+			Assert.Null(context.Result);
+			Assert.True(context.ModelState.IsValid);
+			Assert.Empty(context.ModelState);
+		}
+
+		[Theory]
+		[InlineData("POST")]
+		[InlineData("post")]
+		public async Task TestPostFail(string httpMethod)
+		{
+			var recaptchaResponse = Guid.NewGuid().ToString();
+			var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
+			var errorMessage = Guid.NewGuid().ToString();
+
+			var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
+			recaptchaService
+				.Setup(a => a.ValidateResponseAsync(recaptchaResponse, ipAddress.ToString()))
+				.Throws(new RecaptchaValidationException(errorMessage, false))
+				.Verifiable();
+
+			var configurationService = new Mock<IRecaptchaConfigurationService>(MockBehavior.Strict);
+			configurationService
+				.Setup(a => a.Enabled)
+				.Returns(true)
+				.Verifiable();
+
+			var sink = new TestSink();
+			var loggerFactory = new TestLoggerFactory(sink, enabled: true);
+
+			var filter = new ValidateRecaptchaFilter(recaptchaService.Object, configurationService.Object, loggerFactory);
+
+			var httpContext = new DefaultHttpContext();
+			httpContext.Request.Method = httpMethod;
+			httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
+			httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+			httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+			{
+				{ "g-recaptcha-response", recaptchaResponse }
+			});
+
+			var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+			var context = new AuthorizationFilterContext(actionContext, new[] { filter });
+
+			await filter.OnAuthorizationAsync(context);
+
+			recaptchaService.Verify();
+
+			Assert.Empty(sink.Scopes);
+			Assert.Single(sink.Writes);
+			Assert.Equal($"Recaptcha validation failed. {errorMessage}", sink.Writes[0].State?.ToString());
+			var httpBadRequest = Assert.IsType<BadRequestResult>(context.Result);
+			Assert.Equal(StatusCodes.Status400BadRequest, httpBadRequest.StatusCode);
+			Assert.True(context.ModelState.IsValid);
+			Assert.Empty(context.ModelState);
+		}
+
+		[Theory]
+		[InlineData("POST")]
+		[InlineData("post")]
+		public async Task TestPostFailInvalidResponse(string httpMethod)
+		{
+			var recaptchaResponse = Guid.NewGuid().ToString();
+			var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
+			var errorMessage = Guid.NewGuid().ToString();
+			var validationMessage = Guid.NewGuid().ToString();
+
+			var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
+			recaptchaService
+				.Setup(a => a.ValidateResponseAsync(recaptchaResponse, ipAddress.ToString()))
+				.Throws(new RecaptchaValidationException(errorMessage, true))
+				.Verifiable();
+
+			recaptchaService
+				.Setup(a => a.ValidationMessage)
+				.Returns(validationMessage)
+				.Verifiable();
+
+
+			var configurationService = new Mock<IRecaptchaConfigurationService>(MockBehavior.Strict);
+			configurationService
+				.Setup(a => a.Enabled)
+				.Returns(true)
+				.Verifiable();
+
+			var sink = new TestSink();
+			var loggerFactory = new TestLoggerFactory(sink, enabled: true);
+
+			var filter = new ValidateRecaptchaFilter(recaptchaService.Object, configurationService.Object, loggerFactory);
+
+			var httpContext = new DefaultHttpContext();
+			httpContext.Request.Method = httpMethod;
+			httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
+			httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+			httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+			{
+				{ "g-recaptcha-response", recaptchaResponse }
+			});
+
+			var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+			var context = new AuthorizationFilterContext(actionContext, new[] { filter });
+
+			await filter.OnAuthorizationAsync(context);
+
+			recaptchaService.Verify();
+
+			Assert.Empty(sink.Scopes);
+			Assert.Single(sink.Writes);
+			Assert.Equal($"Recaptcha validation failed. {errorMessage}", sink.Writes[0].State?.ToString());
+			Assert.Null(context.Result);
+			Assert.False(context.ModelState.IsValid);
+			Assert.NotEmpty(context.ModelState);
+			Assert.NotNull(context.ModelState["g-recaptcha-response"]);
+			Assert.Equal(1, context.ModelState["g-recaptcha-response"].Errors.Count);
+			Assert.Equal(validationMessage, context.ModelState["g-recaptcha-response"].Errors.First().ErrorMessage);
+		}
+
+		[Theory]
+		[InlineData("POST")]
+		[InlineData("post")]
+		public async Task TestPostWrongContentType(string httpMethod)
+		{
+			var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
+			recaptchaService
+				.Setup(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()))
+				.Verifiable();
+
+			var configurationService = new Mock<IRecaptchaConfigurationService>(MockBehavior.Strict);
+			configurationService
+				.Setup(a => a.Enabled)
+				.Returns(true)
+				.Verifiable();
+
+			var sink = new TestSink();
+			var loggerFactory = new TestLoggerFactory(sink, enabled: true);
+
+			var filter = new ValidateRecaptchaFilter(recaptchaService.Object, configurationService.Object, loggerFactory);
+
+			var httpContext = new DefaultHttpContext();
+			httpContext.Request.Method = httpMethod;
+			httpContext.Request.ContentType = "Wrong content type";
+
+			var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+			var context = new AuthorizationFilterContext(actionContext, new[] { filter });
+
+			recaptchaService.Verify(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+
+			await filter.OnAuthorizationAsync(context);
+
+			Assert.Empty(sink.Scopes);
+			Assert.Single(sink.Writes);
+			Assert.Equal($"Recaptcha validation failed. The content type is 'Wrong content type', it should be form content.", sink.Writes[0].State?.ToString());
+			var httpBadRequest = Assert.IsType<BadRequestResult>(context.Result);
+			Assert.Equal(StatusCodes.Status400BadRequest, httpBadRequest.StatusCode);
+			Assert.True(context.ModelState.IsValid);
+			Assert.Empty(context.ModelState);
+		}
+
+		[Theory]
+		[InlineData("POST")]
+		[InlineData("post")]
+		public async Task TestPostFailMissingResponse(string httpMethod)
+		{
+			var recaptchaResponse = string.Empty;
+			var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
+			var errorMessage = Guid.NewGuid().ToString();
+			var validationMessage = Guid.NewGuid().ToString();
+
+			var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
+			recaptchaService
+				.Setup(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()))
+				.Returns(Task.FromResult(0))
+				.Verifiable();
+
+			recaptchaService
+				.Setup(a => a.ValidationMessage)
+				.Returns(validationMessage)
+				.Verifiable();
+
+			var configurationService = new Mock<IRecaptchaConfigurationService>(MockBehavior.Strict);
+			configurationService
+				.Setup(a => a.Enabled)
+				.Returns(true)
+				.Verifiable();
+
+			var filter = new ValidateRecaptchaFilter(recaptchaService.Object, configurationService.Object, NullLoggerFactory.Instance);
+
+			var httpContext = new DefaultHttpContext();
+			httpContext.Request.Method = httpMethod;
+			httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
+			httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+			httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+			{
+				{ "g-recaptcha-response", recaptchaResponse }
+			});
+
+			var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+			var context = new AuthorizationFilterContext(actionContext, new[] { filter });
+
+			await filter.OnAuthorizationAsync(context);
+
+			recaptchaService.Verify(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+
+			Assert.Null(context.Result);
+			Assert.False(context.ModelState.IsValid);
+			Assert.NotEmpty(context.ModelState);
+			Assert.NotNull(context.ModelState["g-recaptcha-response"]);
+			Assert.Equal(1, context.ModelState["g-recaptcha-response"].Errors.Count);
+			Assert.Equal(validationMessage, context.ModelState["g-recaptcha-response"].Errors.First().ErrorMessage);
+		}
+
+		[Fact]
+		public async Task DoNotValidateIfDisabled()
+		{
+			var recaptchaResponse = string.Empty;
+			var ipAddress = new IPAddress(new byte[] { 127, 0, 0, 1 });
+			var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
+
+			var configurationService = new Mock<IRecaptchaConfigurationService>(MockBehavior.Strict);
+			configurationService
+				.Setup(a => a.Enabled)
+				.Returns(false)
+				.Verifiable();
+
+			var filter = new ValidateRecaptchaFilter(recaptchaService.Object, configurationService.Object, NullLoggerFactory.Instance);
+
+			var httpContext = new DefaultHttpContext();
+			httpContext.Request.Method = "POST";
+			httpContext.Request.HttpContext.Connection.RemoteIpAddress = ipAddress;
+			httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+			httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+			{
+				{ "g-recaptcha-response", recaptchaResponse }
+			});
+
+			var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+			var context = new AuthorizationFilterContext(actionContext, new[] { filter });
+
+			await filter.OnAuthorizationAsync(context);
+
+			Assert.Null(context.Result);
+
+			configurationService.Verify();
+			recaptchaService.Verify();
+		}
+
+		[Theory]
+		[InlineData("GET")]
+		[InlineData("PUT")]
+		[InlineData("DELETE")]
+		[InlineData("HEAD")]
+		[InlineData("TRACE")]
+		[InlineData("OPTIONS")]
+		public async Task TestPostSkipping(string httpMethod)
+		{
+			var recaptchaService = new Mock<IRecaptchaValidationService>(MockBehavior.Strict);
+			recaptchaService
+				.Setup(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()))
+				.Returns(Task.FromResult(0))
+				.Verifiable();
+
+			var configurationService = new Mock<IRecaptchaConfigurationService>(MockBehavior.Strict);
+			configurationService
+				.Setup(a => a.Enabled)
+				.Returns(true)
+				.Verifiable();
+
+			var filter = new ValidateRecaptchaFilter(recaptchaService.Object, configurationService.Object, NullLoggerFactory.Instance);
+
+			var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
+			actionContext.HttpContext.Request.Method = httpMethod;
+
+			var context = new AuthorizationFilterContext(actionContext, new[] { filter });
+
+			await filter.OnAuthorizationAsync(context);
+
+			recaptchaService.Verify(a => a.ValidateResponseAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+
+			Assert.Null(context.Result);
+			Assert.True(context.ModelState.IsValid);
+			Assert.Empty(context.ModelState);
+		}
+	}
 }

--- a/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/project.json
+++ b/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/project.json
@@ -14,7 +14,7 @@
     "xunit": "2.2.0-*",
     "Microsoft.AspNetCore.TestHost": "1.0.0",
     "PaulMiami.AspNetCore.Mvc.Recaptcha": { "target": "project" },
-    "Microsoft.Extensions.Logging.Testing": "1.1.0-*",
+    "Microsoft.Extensions.Logging.Testing": "1.2.0-preview1-22849",
     "Moq": "4.6.38-*",
     "TestSite":  {"target": "project"}
   },


### PR DESCRIPTION
A new IRecaptchaConfigurationService.Enabled options to disable reCaptcha scripts rendering, POST validation etc. if it is set to false.