### PR TITLE
Add support for Recaptcha invisible.

### DIFF
--- a/sample/TestWebApp/Controllers/TestEmailNewsletterSignupController.cs
+++ b/sample/TestWebApp/Controllers/TestEmailNewsletterSignupController.cs
@@ -98,6 +98,24 @@ namespace TestWebApp.Controllers
         }
 
         [HttpGet]
+        public IActionResult Invisible()
+        {
+            return View();
+        }
+
+        [ValidateRecaptcha]
+        [HttpPost]
+        public IActionResult Invisible(TestEmailNewsletterViewModel viewModel)
+        {
+            if (ModelState.IsValid)
+            {
+                return RedirectToAction(nameof(ThankYou), new { name = viewModel.Name });
+            }
+
+            return View();
+        }
+
+        [HttpGet]
         public IActionResult ThankYou(string name)
         {
             return View(nameof(ThankYou), name);

--- a/sample/TestWebApp/Views/Shared/_Layout.cshtml
+++ b/sample/TestWebApp/Views/Shared/_Layout.cshtml
@@ -26,6 +26,7 @@
                     <li><a asp-controller="TestEmailNewsletterSignup" asp-action="DarkTheme">Dark theme</a></li>
                     <li><a asp-controller="TestEmailNewsletterSignup" asp-action="Compact">Compact size</a></li>
                     <li><a asp-controller="TestEmailNewsletterSignup" asp-action="Audio">Audio type</a></li>
+                    <li><a asp-controller="TestEmailNewsletterSignup" asp-action="Invisible">Invisible recaptcha type</a></li>
                     <li><a asp-controller="TestEmailNewsletterSignup" asp-action="JqueryValidationDisabled">Jqyery validation disabled</a></li>
                 </ul>
             </div>

--- a/sample/TestWebApp/Views/TestEmailNewsletterSignup/Invisible.cshtml
+++ b/sample/TestWebApp/Views/TestEmailNewsletterSignup/Invisible.cshtml
@@ -1,0 +1,42 @@
+﻿@{
+    ViewBag.Title = "Signup for our awesome newsletter";
+}
+@model TestEmailNewsletterViewModel
+@using PaulMiami.AspNetCore.Mvc.Recaptcha
+
+
+<form asp-controller="TestEmailNewsletterSignup" asp-action="Invisible" method="post" class="form-horizontal" id="demo-form">
+    <h4>@ViewBag.Title</h4>
+    <hr />
+    <div asp-validation-summary="All" class="text-danger"></div>
+    <div class="form-group">
+        <label asp-for="Name" class="col-md-2 control-label"></label>
+        <div class="col-md-10">
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+    </div>
+    <div class="form-group">
+        <label asp-for="Email" class="col-md-2 control-label"></label>
+        <div class="col-md-10">
+            <input asp-for="Email" class="form-control" />
+            <span asp-validation-for="Email" class="text-danger"></span>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-offset-2 col-md-10">
+            <span class="text-danger" id="recaptchaErrorMessage"></span>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-offset-2 col-md-10">
+            <input type="submit" class="btn btn-default" value="Submit" for-recaptcha-form="demo-form" />
+        </div>
+    </div>
+
+</form>
+
+@section Scripts {
+    <recaptcha-script validation-message-element-id="recaptchaErrorMessage" jquery-validation="false" />
+    <recaptcha-invisible-script form-id="demo-form" jquery-validation="false" />
+}

--- a/src/PaulMiami.AspNetCore.Mvc.Recaptcha/TagHelpers/InputTagHelper.cs
+++ b/src/PaulMiami.AspNetCore.Mvc.Recaptcha/TagHelpers/InputTagHelper.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace PaulMiami.AspNetCore.Mvc.Recaptcha.TagHelpers
+{
+    [HtmlTargetElement("input", Attributes = ForRecaptchaFormAttributeName, TagStructure = TagStructure.WithoutEndTag)]
+    [HtmlTargetElement("button", Attributes = ForRecaptchaFormAttributeName, TagStructure = TagStructure.NormalOrSelfClosing)]
+    public class InputTagHelper : TagHelper
+    {
+        private const string ForRecaptchaFormAttributeName = "for-recaptcha-form";
+        private const string DataCallBackAttributeName = "data-callback";
+        private const string DataSizeAttributeName = "data-size";
+        private const string DataSiteKeyAttributeName = "data-sitekey";
+        private const string OnClickAttributeName = "onclick";
+        private const string CssClassAttribute = "class";
+
+        private readonly IRecaptchaConfigurationService _service;
+
+        [HtmlAttributeName(ForRecaptchaFormAttributeName)]
+        public string FormId { get; set; }
+
+        public InputTagHelper(IRecaptchaConfigurationService service)
+        {
+            service.CheckArgumentNull(nameof(service));
+
+            _service = service;
+        }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (!_service.Enabled)
+            {
+                base.Process(context, output);
+                return;
+            }
+
+            output.Attributes.Add(OnClickAttributeName, RecaptchaInvisibleScriptTagHelper.GetOnClickFunctionName(FormId) + "(event)");
+            output.PostElement.AppendHtml(CreateRecaptchaDivTag());
+
+            base.Process(context, output);
+        }
+
+        private TagBuilder CreateRecaptchaDivTag()
+        {
+            var div = new TagBuilder("div");
+
+            div.TagRenderMode = TagRenderMode.Normal;
+            div.Attributes.Add(CssClassAttribute, "g-recaptcha");
+            div.Attributes.Add(DataSiteKeyAttributeName, _service.SiteKey);
+            div.Attributes.Add(DataCallBackAttributeName, RecaptchaInvisibleScriptTagHelper.GetOnSubmitFunctionName(FormId));
+            div.Attributes.Add(DataSizeAttributeName, "invisible");
+
+            return div;
+        }
+    }
+}

--- a/src/PaulMiami.AspNetCore.Mvc.Recaptcha/TagHelpers/RecaptchaInvisibleScriptTagHelper.cs
+++ b/src/PaulMiami.AspNetCore.Mvc.Recaptcha/TagHelpers/RecaptchaInvisibleScriptTagHelper.cs
@@ -1,0 +1,82 @@
+﻿using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace PaulMiami.AspNetCore.Mvc.Recaptcha.TagHelpers
+{
+    [HtmlTargetElement("recaptcha-invisible-script", Attributes = FormIdAttributeName, TagStructure = TagStructure.NormalOrSelfClosing)]
+    public class RecaptchaInvisibleScriptTagHelper : TagHelper
+    {
+        private const string FormIdAttributeName = "form-id";
+        private const string JqueryValidationAttributeName = "jquery-validation";
+
+        private const string ScriptSnippetJValidate = "function {0}(token) {{ document.getElementById('{1}').submit(); }} function {2}(e) {{ e.preventDefault(); $('#{1}').validate(); if ($('#{1}').valid()) grecaptcha.execute(); }}";
+        private const string ScriptSnippetNoValidate = "function {0}(token) {{ document.getElementById('{1}').submit(); }} function {2}(e) {{ e.preventDefault(); grecaptcha.execute(); }}";
+
+        private readonly IRecaptchaConfigurationService _service;
+
+        [HtmlAttributeName(FormIdAttributeName)]
+        public string FormId { get; set; }
+
+        [HtmlAttributeName(JqueryValidationAttributeName)]
+        public bool? JqueryValidation { get; set; }
+
+        public RecaptchaInvisibleScriptTagHelper(RecaptchaService service)
+        {
+            service.CheckArgumentNull(nameof(service));
+
+            _service = service;
+        }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (!_service.Enabled)
+            {
+                output.TagName = null;
+                return;
+            }
+
+            output.TagName = "script";
+            output.TagMode = TagMode.StartTagAndEndTag;
+            output.Content.SetHtmlContent(GetScript());
+
+            base.Process(context, output);
+        }
+
+        private string GetScript()
+        {
+            if (JqueryValidation ?? true)
+            {
+                return string.Format(ScriptSnippetJValidate, GetOnSubmitFunctionName(FormId), FormId, GetOnClickFunctionName(FormId));
+            }
+            else
+            {
+                return string.Format(ScriptSnippetNoValidate, GetOnSubmitFunctionName(FormId), FormId, GetOnClickFunctionName(FormId));
+            }
+        }
+
+        internal static string GetOnSubmitFunctionName(string formId)
+        {
+            return GetFunctionNameForFormId(formId, "onSubmit");
+        }
+
+        internal static string GetOnClickFunctionName(string formId)
+        {
+            return GetFunctionNameForFormId(formId, "onClick");
+        }
+
+        private static string GetFunctionNameForFormId(string formId, string prefix)
+        {
+            var functionNameBuilder = new StringBuilder(prefix);
+
+            foreach (var match in Regex.Matches(formId, "[A-Za-z0-9_]+"))
+            {
+                var pascalCasedPart = match.ToString().First().ToString().ToUpper() + match.ToString().Substring(1);
+                functionNameBuilder.Append(pascalCasedPart);
+            }
+
+            return functionNameBuilder.ToString();
+        }
+    }
+}

--- a/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/TagHelpers/InputTagHelperTest.cs
+++ b/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/TagHelpers/InputTagHelperTest.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using PaulMiami.AspNetCore.Mvc.Recaptcha.TagHelpers;
+
+namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test.TagHelpers
+{
+    public class InputTagHelperTest
+    {
+        private readonly string _siteKey = Guid.NewGuid().ToString();
+        private readonly string _secretKey = Guid.NewGuid().ToString();
+
+        public IOptions<RecaptchaOptions> GetOptions()
+        {
+            return new OptionsWrapper<RecaptchaOptions>(new RecaptchaOptions
+            {
+                SiteKey = _siteKey,
+                SecretKey = _secretKey
+            });
+        }
+
+        private TagHelperOutput ProcessTagHelper(RecaptchaService service, TagHelperAttributeList attributes, Action<InputTagHelper> config = null)
+        {
+            var tagHelper = new InputTagHelper(service);
+
+            config?.Invoke(tagHelper);
+
+            var tagHelperContext = new TagHelperContext(
+               allAttributes: new TagHelperAttributeList(),
+               items: new Dictionary<object, object>(),
+               uniqueId: "test");
+
+            var output = new TagHelperOutput(
+                tagName: "doesntmatter",
+                attributes: attributes,
+                getChildContentAsync: (useCachedResult, encoder) =>
+                {
+                    return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+                });
+
+            tagHelper.Process(tagHelperContext, output);
+
+            return output;
+        }
+
+        [Fact]
+        public void MissingService()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new InputTagHelper(null));
+        }
+
+        [Fact]
+        public void DoNotRenderIfDisabled()
+        {
+            var options = GetOptions();
+            options.Value.Enabled = false;
+            var service = new RecaptchaService(options);
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList());
+
+            Assert.False(output.Attributes.ContainsName("onclick"));
+            Assert.True(output.PostElement.IsEmptyOrWhiteSpace);
+        }
+
+        [Fact]
+        public void CreatesOnClickAttribute()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+            var formId = "frm";
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => th.FormId = formId);
+
+            Assert.True(output.Attributes.ContainsName("onclick"));
+            Assert.Equal("onClickFrm(event)", output.Attributes["onclick"].Value);
+        }
+
+        [Fact]
+        public void OnClickAttributeStripsHyphen()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+            var formId = "frm-id";
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => th.FormId = formId);
+
+            Assert.True(output.Attributes.ContainsName("onclick"));
+            Assert.Equal("onClickFrmId(event)", output.Attributes["onclick"].Value);
+        }
+
+        [Fact]
+        public void CreatesRecaptchaDivWithCorrectAttributes()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+            var formId = "frm";
+            var expectedFunction = "onSubmitFrm";
+            var expected = $"<div class=\"g-recaptcha\" data-callback=\"{expectedFunction}\" data-sitekey=\"{options.Value.SiteKey}\" data-size=\"invisible\"></div>";
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => th.FormId = formId);
+
+            Assert.False(output.PostElement.IsEmptyOrWhiteSpace);
+            Assert.Equal(expected, output.PostElement.GetContent());
+        }
+
+        [Fact]
+        public void OnSubmitAttributeStripsHyphen()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+            var formId = "frm-id";
+            var expectedFunction = "onSubmitFrmId";
+            var expected = $"<div class=\"g-recaptcha\" data-callback=\"{expectedFunction}\" data-sitekey=\"{options.Value.SiteKey}\" data-size=\"invisible\"></div>";
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => th.FormId = formId);
+
+            Assert.False(output.PostElement.IsEmptyOrWhiteSpace);
+            Assert.Equal(expected, output.PostElement.GetContent());
+        }
+    }
+}

--- a/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/TagHelpers/RecaptchaInvisibleScriptTagHelperTest.cs
+++ b/test/PaulMiami.AspNetCore.Mvc.Recaptcha.Test/TagHelpers/RecaptchaInvisibleScriptTagHelperTest.cs
@@ -1,0 +1,141 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Options;
+using PaulMiami.AspNetCore.Mvc.Recaptcha.TagHelpers;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PaulMiami.AspNetCore.Mvc.Recaptcha.Test.TagHelpers
+{
+    public class RecaptchaInvisibleScriptTagHelperTest
+    {
+        private readonly string _siteKey = Guid.NewGuid().ToString();
+        private readonly string _secretKey = Guid.NewGuid().ToString();
+
+        public IOptions<RecaptchaOptions> GetOptions()
+        {
+            return new OptionsWrapper<RecaptchaOptions>(new RecaptchaOptions
+            {
+                SiteKey = _siteKey,
+                SecretKey = _secretKey
+            });
+        }
+
+        private TagHelperOutput ProcessTagHelper(RecaptchaService service, TagHelperAttributeList attributes, Action<RecaptchaInvisibleScriptTagHelper> config = null)
+        {
+            var tagHelper = new RecaptchaInvisibleScriptTagHelper(service);
+
+            config?.Invoke(tagHelper);
+
+            var tagHelperContext = new TagHelperContext(
+               allAttributes: new TagHelperAttributeList(),
+               items: new Dictionary<object, object>(),
+               uniqueId: "test");
+
+            var output = new TagHelperOutput(
+                tagName: "doesntmatter",
+                attributes: attributes,
+                getChildContentAsync: (useCachedResult, encoder) =>
+                {
+                    return Task.FromResult<TagHelperContent>(new DefaultTagHelperContent());
+                });
+
+            tagHelper.Process(tagHelperContext, output);
+
+            return output;
+        }
+
+        [Fact]
+        public void MissingService()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new RecaptchaInvisibleScriptTagHelper(null));
+        }
+
+        [Fact]
+        public void DoNotRenderIfDisabled()
+        {
+            var options = GetOptions();
+            options.Value.Enabled = false;
+            var service = new RecaptchaService(options);
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList());
+
+            Assert.Null(output.TagName);
+            Assert.False(output.IsContentModified);
+            Assert.Empty(output.Attributes);
+        }
+
+        [Fact]
+        public void HasOnClickFunction()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => th.FormId = "frm");
+
+            Assert.Contains("function onClickFrm(e)", output.Content.GetContent());
+        }
+
+        [Fact]
+        public void OnClickStripsHyphens()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => th.FormId = "frm-id");
+
+            Assert.Contains("function onClickFrmId(e)", output.Content.GetContent());
+        }
+
+        [Fact]
+        public void HasOnSubmitFunction()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => th.FormId = "frm");
+
+            Assert.Contains("function onSubmitFrm(token)", output.Content.GetContent());
+        }
+
+        [Fact]
+        public void OnSubmitStripsHyphens()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => th.FormId = "frm-id");
+
+            Assert.Contains("function onSubmitFrmId(token)", output.Content.GetContent());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(null)]
+        public void CallsJqueryValidate(bool? jQueryValidateAttributeValue)
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => { th.FormId = "frm"; th.JqueryValidation = jQueryValidateAttributeValue; });
+
+            Assert.Contains("$('", output.Content.GetContent());
+            Assert.Contains(".validate()", output.Content.GetContent());
+            Assert.Contains(".valid()", output.Content.GetContent());
+        }
+
+        [Fact]
+        public void DoesNotCallJqueryValidateIfEnabled()
+        {
+            var options = GetOptions();
+            var service = new RecaptchaService(options);
+
+            var output = ProcessTagHelper(service, new TagHelperAttributeList(), th => { th.FormId = "frm"; th.JqueryValidation = false; });
+
+            Assert.DoesNotContain("$('", output.Content.GetContent());
+            Assert.DoesNotContain(".validate()", output.Content.GetContent());
+            Assert.DoesNotContain(".valid()", output.Content.GetContent());
+        }
+    }
+}


### PR DESCRIPTION
I added support for Recaptcha invisible with this pull request. This resolves issue #16.

This includes a working example (sample\TestWebApp\Views\TestEmailNewsletterSignup)

The pull request also includes unit tests on the new code.